### PR TITLE
Mbs 6019 adding cli script to check installed libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ sudo dnf install libwebp-tools
 
 sudo dnf install pngquant
 ```
+### Check Setup.
+To check if, e.g. on the cron job server (web server cluster), all prerequisites are met, you can run the following CLI script on the console:
+
+```$bash
+php admin/tool/imageoptimize/cli/check_installed_modules.php
+``` 
+The results of this script are stored in config and affects the display in settings.php. Even if the cron jobs are executed via a separate server, the settings will show whether all libraries are installed.
 
 ### PHP
 

--- a/classes/tool_image_optimize_helper.php
+++ b/classes/tool_image_optimize_helper.php
@@ -463,7 +463,7 @@ class tool_image_optimize_helper extends \tool_image_optimize {
         }
 
         $this->config->filessortorder = $options['sort'];
-        $this->process_files($options['chunksize']);
+        $this->process_files((int)$options['chunksize']);
     }
 
     /**

--- a/cli/check_requirements.php
+++ b/cli/check_requirements.php
@@ -1,0 +1,72 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * With this script it can be checked if all needed modules are installed on that server used to process background optimization.
+ *
+ * @package    tool_imageoptimize
+ * @copyright  2021 ISB Bayern
+ * @author     Peter Mayer, peter.mayer@isb.bayern.de
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('CLI_SCRIPT', true);
+
+require_once(dirname(__FILE__) . '/../../../../config.php');
+require_once($CFG->libdir . "/clilib.php");
+require_once($CFG->dirroot . '/admin/tool/imageoptimize/tool_imageoptimize.php');
+\core_php_time_limit::raise();
+
+use \tool_imageoptimize\tool_image_optimize_helper;
+
+$imageoptimizehelper = tool_image_optimize_helper::get_instance();
+
+$alloverstatus = true;
+
+
+$imageoptimize = new tool_image_optimize();
+
+if (!$imageoptimize->os_check()) {
+    mtrace("Your OS is not compatible. Please consult the documentation.");
+    mtrace("Abort!");
+    set_config('oscompatible', false, 'tool_imageoptimize');
+    die;
+} else {
+    set_config('oscompatible', true, 'tool_imageoptimize');
+}
+
+if (!$imageoptimize->exec_enabled()) {
+    mtrace("Enable php core function exec() first.");
+    mtrace("Abort!");
+    set_config('execenabled', false, 'tool_imageoptimize');
+    die;
+} else {
+    set_config('execenabled', true, 'tool_imageoptimize');
+}
+
+foreach (array_keys($imageoptimize::PACKAGES) as $package) {
+    if (!$imageoptimizehelper->check_package_command_for_testing($package)) {
+        mtrace($package . " is missing! Please execute:\napt-get install " . $package);
+        set_config($package . '_installed', false, 'tool_imageoptimize');
+        $alloverstatus = false;
+    } else {
+        set_config($package . '_installed', true, 'tool_imageoptimize');
+    }
+}
+
+if ($alloverstatus) {
+    mtrace("All modules are installed.");
+}

--- a/lang/de/tool_imageoptimize.php
+++ b/lang/de/tool_imageoptimize.php
@@ -48,7 +48,7 @@ $string['exec_warning'] = 'Für die Funktion dieses Plugins müssen Sie einige E
                             <li>Installieren Sie die für die Komprimierung erforderlichen Pakete für jeden Image-Typ auf dem Server</li>
                         </ol>';
 $string['info_title'] = 'Um die Formatkomprimierungsfunktion <strong> {$a} </strong> zu erweitern, können Sie zusätzliche Pakete für die Komprimierung installieren';
-$string['warning_title'] = 'Installieren Sie eines der Pakete auf Ihrem Server oder alle zusammen, damit die Option angezeigt wird';
+$string['warning_title'] = 'Installieren Sie eines der Pakete auf Ihrem Server oder alle zusammen, damit die Option verwendet werden kann:';
 $string['jpegoptim'] = '<strong> <a href="http://freshmeat.sourceforge.net/projects/jpegoptim" target="_blank"> JpegOptim </a> </strong>
                         <ul>
                             <li> <strong> Debian / Ubuntu </strong>: <code> sudo apt-get install jpegoptim </code> </li>

--- a/settings.php
+++ b/settings.php
@@ -54,7 +54,7 @@ if ($hassiteconfig) {
     foreach (tool_image_optimize::PACKAGES as $package => $imageextension) {
         if (!get_config('tool_imageoptimize', $package . "_installed")) {
             if (!$imageoptimize->can_handle_file_extension($imageextension)) {
-                $warning = $package . get_string('warning_title', 'tool_imageoptimize') . '<ol>';
+                $warning = get_string('warning_title', 'tool_imageoptimize') . '<ol>';
                 foreach (tool_image_optimize::PACKAGES_TYPES[$imageextension] as $package) {
                     $warning .= '<li>' . get_string($package, 'tool_imageoptimize') . '</li>';
                 }

--- a/settings.php
+++ b/settings.php
@@ -51,33 +51,34 @@ if ($hassiteconfig) {
         ));
     }
 
-    foreach (array_keys(tool_image_optimize::PACKAGES_TYPES) as $imageextension) {
-        if (!$imageoptimize->can_handle_file_extension($imageextension)) {
-            $warning = get_string('warning_title', 'tool_imageoptimize') . '<ol>';
+    foreach (tool_image_optimize::PACKAGES as $package => $imageextension) {
+        if (!get_config('tool_imageoptimize', $package . "_installed")) {
+            if (!$imageoptimize->can_handle_file_extension($imageextension)) {
+                $warning = $package . get_string('warning_title', 'tool_imageoptimize') . '<ol>';
+                foreach (tool_image_optimize::PACKAGES_TYPES[$imageextension] as $package) {
+                    $warning .= '<li>' . get_string($package, 'tool_imageoptimize') . '</li>';
+                }
+                $warning .= '</ol>';
+                $settings->add(new tool_imageoptimize_notification(
+                    'tool_imageoptimize/' . $imageextension . '_head_warninig',
+                    $imageextension . '_head_warninig',
+                    $warning,
+                    'warning'
+                ));
+            }
+            $info = '';
             foreach (tool_image_optimize::PACKAGES_TYPES[$imageextension] as $package) {
-                $warning .= '<li>' . get_string($package, 'tool_imageoptimize') . '</li>';
+                if (!$imageoptimize->check_package($package)) {
+                    $info .= '<li>' . get_string($package, 'tool_imageoptimize') . '</li>';
+                }
             }
-            $warning .= '</ol>';
-            $settings->add(new tool_imageoptimize_notification(
-                'tool_imageoptimize/' . $imageextension . '_head_warninig',
-                $imageextension . '_head_warninig',
-                $warning,
-                'warning'
-            ));
-        }
-
-        $info = '';
-        foreach (tool_image_optimize::PACKAGES_TYPES[$imageextension] as $package) {
-            if (!$imageoptimize->check_package($package)) {
-                $info .= '<li>' . get_string($package, 'tool_imageoptimize') . '</li>';
+            if ($info) {
+                $settings->add(new tool_imageoptimize_notification(
+                    'tool_imageoptimize/extensions_warning',
+                    'extensions_warning',
+                    get_string('info_title', 'tool_imageoptimize') . '<ol>' . $info . '</ol>'
+                ));
             }
-        }
-        if ($info) {
-            $settings->add(new tool_imageoptimize_notification(
-                'tool_imageoptimize/extensions_warning',
-                'extensions_warning',
-                get_string('info_title', 'tool_imageoptimize') . '<ol>' . $info . '</ol>'
-            ));
         }
     }
 

--- a/tests/imageoptimize_task_test.php
+++ b/tests/imageoptimize_task_test.php
@@ -176,7 +176,7 @@ class imageoptimize_task_test extends advanced_testcase {
             // Check if old file does not exist any more.
             $fulldirold = $filesystemhelper->get_fulldir_from_hash_imgopt($imgoptfile->contenthashold);
             $fileold = $fulldirold . "/" . $imgoptfile->contenthashold;
-            $this->assertFileNotExists($fileold);
+            $this->assertFileDoesNotExist($fileold);
 
             // Check if filesizenew is set in tool_imageoptimize_files and is equal to the filesize of the physical file.
             $this->assertEquals($imgoptfile->filesize, filesize($filenew));
@@ -220,7 +220,7 @@ class imageoptimize_task_test extends advanced_testcase {
             // Check if old file does not exist any more.
             $fulldirold = $filesystemhelper->get_fulldir_from_hash_imgopt($imgoptfile->contenthashold);
             $fileold = $fulldirold . "/" . $imgoptfile->contenthashold;
-            $this->assertFileNotExists($fileold);
+            $this->assertFileDoesNotExist($fileold);
 
             // Check if filesizenew is set in tool_imageoptimize_files and is equal to the filesize of the physical file.
             $this->assertEquals($imgoptfile->filesize, filesize($filenew));
@@ -251,7 +251,7 @@ class imageoptimize_task_test extends advanced_testcase {
         $fulldirmissingfile = $filesystemhelper->get_fulldir_from_hash_imgopt($missingfile->contenthash);
         unlink($fulldirmissingfile . "/" . $missingfile->contenthash);
 
-        $this->assertFileNotExists($fulldirmissingfile . "/" . $missingfile->contenthash);
+        $this->assertFileDoesNotExist($fulldirmissingfile . "/" . $missingfile->contenthash);
 
         // Set filesortorder to oldest files first.
         set_config('filessortorder', 'iddesc', 'tool_imageoptimize');
@@ -297,7 +297,7 @@ class imageoptimize_task_test extends advanced_testcase {
         $fulldirmissingfile = $filesystemhelper->get_fulldir_from_hash_imgopt($missingfile->contenthash);
         unlink($fulldirmissingfile . "/" . $missingfile->contenthash);
 
-        $this->assertFileNotExists($fulldirmissingfile . "/" . $missingfile->contenthash);
+        $this->assertFileDoesNotExist($fulldirmissingfile . "/" . $missingfile->contenthash);
 
         // Set filesortorder to oldest files first.
         set_config('filessortorder', 'iddesc', 'tool_imageoptimize');
@@ -345,7 +345,7 @@ class imageoptimize_task_test extends advanced_testcase {
         $fulldirmissingfile = $filesystemhelper->get_fulldir_from_hash_imgopt($missingfile->contenthash);
         unlink($fulldirmissingfile . "/" . $missingfile->contenthash);
 
-        $this->assertFileNotExists($fulldirmissingfile . "/" . $missingfile->contenthash);
+        $this->assertFileDoesNotExist($fulldirmissingfile . "/" . $missingfile->contenthash);
 
         // Set filesortorder to oldest files first.
         set_config('filessortorder', 'iddesc', 'tool_imageoptimize');

--- a/tool_imageoptimize.php
+++ b/tool_imageoptimize.php
@@ -106,7 +106,11 @@ class tool_image_optimize {
     protected const COMPONENT = 'tool_imageoptimize';
 
     public const PACKAGES = [
-        'jpegoptim', 'optipng', 'gifsicle'
+        'jpegoptim' => 'jpg',
+        'optipng' => 'png',
+        'gifsicle' => 'gif',
+        'webp' => 'jpg',
+        'pngquant' => 'png',
     ];
 
     public const PACKAGES_WEBP = [
@@ -142,7 +146,7 @@ class tool_image_optimize {
             $this->sourcefilerecord = $sourcefilerecord;
         }
         $this->oscheck = $this->os_check();
-        // $this->exec = $this->exec_enabled();
+        $this->exec = $this->exec_enabled();
         // $this->jpegoptim = $this->check_package('jpegoptim');
         // $this->optipng = $this->check_package('optipng');
         // $this->gifsicle = $this->check_package('gifsicle');
@@ -155,6 +159,9 @@ class tool_image_optimize {
      * @return bool
      */
     public function get_exec() : bool {
+        if (get_config('tool_imageoptimize', "enablebackgroundoptimizing")) {
+            return get_config('tool_imageoptimize', "execenabled");
+        }
         return $this->exec;
     }
 
@@ -164,6 +171,9 @@ class tool_image_optimize {
      * @return bool
      */
     public function get_os_check() : bool {
+        if (get_config('tool_imageoptimize', "enablebackgroundoptimizing")) {
+            return get_config('tool_imageoptimize', "oscompatible");
+        }
         return $this->oscheck;
     }
 
@@ -195,7 +205,7 @@ class tool_image_optimize {
      *
      * @return bool
      */
-    protected function exec_enabled() : bool {
+    public function exec_enabled() : bool {
         if ($this->get_os_check()) {
             return !in_array('exec', explode(',', ini_get('disable_functions')));
         }
@@ -253,7 +263,7 @@ class tool_image_optimize {
     public function check_package(string $name) : bool {
         if ($this->get_exec()) {
             if ($name != 'webp') {
-                if (in_array($name, self::PACKAGES)) {
+                if (in_array($name, array_keys(self::PACKAGES))) {
                     if ($this->check_package_command($name)) {
                         return true;
                     }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021020200; // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2021120700; // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019111800; // Requires this Moodle version.
 $plugin->release   = '1.0.3 (Build: 2021020200)';
 $plugin->component = 'tool_imageoptimize'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
This change adds a CLI script that can be used to check the system requirements.
This is especially useful if the cron runs over a separate web server.
The corresponding ToDos are then displayed in the settings if necessary.